### PR TITLE
safariでpositionの指定が上手く行かないバグ修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-modal-manager",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "description": "svelte-modal-manager is ...",
   "keywords": [

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -91,24 +91,38 @@
     height: 100%;
   }
   .f {
+    display: -webkit-flex;
+    display: -moz-flex;
     display: flex;
   }
-  .fl {
-    justify-content: left;
-  }
   .fc {
+    -webkit-justify-content: center;
+    -moz-justify-content: center;
     justify-content: center;
   }
-  .fr {
-    justify-content: right;
-  }
-  .ft {
-    align-items: top;
-  }
   .fm {
+    -webkit-align-items: center;
+    -moz-align-items: center;
     align-items: center;
   }
+  .ft {
+    -webkit-align-items: flex-start;
+    -moz-align-items: flex-start;
+    align-items: flex-start;
+  }
+  .fr {
+    -webkit-justify-content: flex-end;
+    -moz-justify-content: flex-end;
+    justify-content: flex-end;
+  }
   .fb {
-    align-items: bottom;
+    -webkit-align-items: flex-end;
+    -moz-align-items: flex-end;
+    align-items: flex-end;
+  }
+  .fl {
+    -webkit-justify-content: flex-start;
+    -moz-justify-content: flex-start;
+    justify-content: flex-start;
   }
 </style>

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -93,22 +93,22 @@
   .f {
     display: flex;
   }
-  .fc {
-    justify-content: center;
-  }
-  .fl {
-    justify-content: flex-start;
+  .ft {
+    align-items: flex-start;
   }
   .fr {
     justify-content: flex-end;
   }
-  .fm {
-    align-items: center;
-  }
-  .ft {
-    align-items: flex-start;
-  }
   .fb {
     align-items: flex-end;
+  }
+  .fl {
+    justify-content: flex-start;
+  }
+  .fc {
+    justify-content: center;
+  }
+  .fm {
+    align-items: center;
   }
 </style>

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -96,8 +96,8 @@
   .ft {
     align-items: flex-start;
   }
-  .fr {
-    justify-content: flex-end;
+  .fm {
+    align-items: center;
   }
   .fb {
     align-items: flex-end;
@@ -108,7 +108,7 @@
   .fc {
     justify-content: center;
   }
-  .fm {
-    align-items: center;
+  .fr {
+    justify-content: flex-end;
   }
 </style>

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -91,38 +91,24 @@
     height: 100%;
   }
   .f {
-    display: -webkit-flex;
-    display: -moz-flex;
     display: flex;
   }
   .fc {
-    -webkit-justify-content: center;
-    -moz-justify-content: center;
     justify-content: center;
   }
+  .fl {
+    justify-content: flex-start;
+  }
+  .fr {
+    justify-content: flex-end;
+  }
   .fm {
-    -webkit-align-items: center;
-    -moz-align-items: center;
     align-items: center;
   }
   .ft {
-    -webkit-align-items: flex-start;
-    -moz-align-items: flex-start;
     align-items: flex-start;
   }
-  .fr {
-    -webkit-justify-content: flex-end;
-    -moz-justify-content: flex-end;
-    justify-content: flex-end;
-  }
   .fb {
-    -webkit-align-items: flex-end;
-    -moz-align-items: flex-end;
     align-items: flex-end;
-  }
-  .fl {
-    -webkit-justify-content: flex-start;
-    -moz-justify-content: flex-start;
-    justify-content: flex-start;
   }
 </style>

--- a/src/lib/modals/SideMenu.svelte
+++ b/src/lib/modals/SideMenu.svelte
@@ -6,12 +6,12 @@
   export const transition = {
     type: fly,
     props: {
-      x: -128,
+      x: 375,
       duration: 256,
     },
   };
   export const position = {
-    x: 'left',
+    x: 'right',
     y: 'middle',
   };
   export const overlay = {


### PR DESCRIPTION
## 詳細
- safariだとSideMenuなどでpositionをright指定をしてもleftが当たってしまうのを修正
- `justify-content`を`right` -> `flex-end`に変更(flex-boxの値をmeltlineと同じ指定に変更)