### PR TITLE
modalを開いたときにblurではなくmodalの枠にfocusするようにする

### DIFF
--- a/src/lib/ModalManager.svelte
+++ b/src/lib/ModalManager.svelte
@@ -36,6 +36,8 @@
     });
 
     _modal.appendChild($elm);
+
+    // デフォルトで modal の枠に focus しておく (ボタン連打等の対策)
     $elm.tabIndex = '-1';
     $elm.focus();
 

--- a/src/lib/ModalManager.svelte
+++ b/src/lib/ModalManager.svelte
@@ -5,9 +5,6 @@
   let _components = {};
 
   export function openModal(component, props = {}) {
-    // focus要素があればblurする
-    document.activeElement.blur();
-
     // 文字列だった場合は登録していあるモーダルからコンポーネントを取得
     if (typeof component === 'string') {
       component = _components[component];
@@ -39,6 +36,8 @@
     });
 
     _modal.appendChild($elm);
+    $elm.tabIndex = '-1';
+    $elm.focus();
 
     // modal を実際に表示
     instance.visible = true;


### PR DESCRIPTION
ボタン連打等の対策とautofocus未指定でもtabキーで違和感のない操作になるように修正
autofocusがあればそちらが優先される
<img width="407" alt="image" src="https://user-images.githubusercontent.com/8247441/160162327-9795b2fe-eacd-42f3-a25d-342c709edb71.png">
