### PR TITLE
テンプレート系のモーダルにテキストカラーを指定

### DIFF
--- a/src/lib/modals/Alert.svelte
+++ b/src/lib/modals/Alert.svelte
@@ -32,6 +32,7 @@
     max-width: 90vw;
     width: 340px;
     background-color: rgba(255, 255, 255, 0.90);
+    color: #222222;
   }
   .bold {
     font-weight: bold;

--- a/src/lib/modals/Confirm.svelte
+++ b/src/lib/modals/Confirm.svelte
@@ -44,6 +44,7 @@
     max-width: 90vw;
     width: 340px;
     background-color: rgba(255, 255, 255, 0.90);
+    color: #222222;
   }
   .bold {
     font-weight: bold;

--- a/src/lib/modals/Prompt.svelte
+++ b/src/lib/modals/Prompt.svelte
@@ -40,6 +40,7 @@
     max-width: 90vw;
     width: 340px;
     background-color: rgba(255, 255, 255, 0.90);
+    color: #222222;
   }
   .bold {
     font-weight: bold;

--- a/src/lib/modals/SideMenu.svelte
+++ b/src/lib/modals/SideMenu.svelte
@@ -61,6 +61,7 @@
     height: 100vh;
     width: 300px;
     background-color: white;
+    color: #222222;
   }
   .bold {
     font-weight: bold;


### PR DESCRIPTION
body に `color:white` があたっているサービスとかだと以下のようになってしまっていたので
modal 自身にも `color` を設定しておくよう修正

## スクショ

before

![image](https://user-images.githubusercontent.com/1156954/160261841-57932c65-aeaa-4d5e-8f15-60e99d9c759a.png)


after

![image](https://user-images.githubusercontent.com/1156954/160261831-47b09442-74c0-49a4-b404-06ab97a8185d.png)
