### PR TITLE
秒数指定すると自動でモーダルが閉じるよう対応

### DIFF
--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -27,7 +27,7 @@
   export let destory;
 
   let root;
-  let timer;
+  let timeoutId;
 
   onMount(() => {
     // デフォルトで modal の枠に focus しておく (ボタン連打等の対策)
@@ -36,8 +36,8 @@
 
     // modal呼ぶ側でtimeoutに秒数を指定した場合にsetTimuoutを実行する
     if (props.timeout) {
-      timer = setTimeout(() => {
-        timer = null;
+      timeoutId = setTimeout(() => {
+        timeoutId = null;
         close();
       }, props.timeout);
     }
@@ -57,9 +57,9 @@
     // trigger close evnet
     dispatch('close');
 
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
     }
     
     if (modal.dispatch) {

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -34,7 +34,7 @@
     root.tabIndex = '-1';
     root.focus();
 
-    // modal呼ぶ側でtimeoutに秒数を指定した場合にsetTimuoutを実行する
+    // modal呼ぶ側でtimeoutに秒数を指定した場合にsetTimeoutを実行する
     if (props.timeout) {
       timeoutId = setTimeout(() => {
         timeoutId = null;

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -35,7 +35,7 @@
     root.focus();
 
     // modal呼ぶ側でtimeoutに秒数を指定した場合にsetTimuoutを実行する
-    if(props.timeout) {
+    if (props.timeout) {
       timer = setTimeout(() => {
         timer = null;
         close();

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -57,6 +57,11 @@
     // trigger close evnet
     dispatch('close');
 
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    
     if (modal.dispatch) {
       modal.dispatch('close');
     }

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -27,11 +27,20 @@
   export let destory;
 
   let root;
+  let timer;
 
   onMount(() => {
     // デフォルトで modal の枠に focus しておく (ボタン連打等の対策)
     root.tabIndex = '-1';
     root.focus();
+
+    // modal呼ぶ側でtimeoutに秒数を指定した場合にsetTimuoutを実行する
+    if(props.timeout) {
+      timer = setTimeout(() => {
+        timer = null;
+        close();
+      }, props.timeout);
+    }
   });
 
   let create = () => {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -186,6 +186,16 @@
         alert('ESC で閉じてね: 3');
       },
     },
+    {
+      label: 'timeout',
+      async action() {
+        let modal = openModal('alert', {
+          title: '2秒後に閉じます',
+          message: 'Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text ',
+          timeout: 2000,
+        });
+      },
+    },
   ];
 
   onMount(() => {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -142,6 +142,15 @@
       },
     },
     {
+      label: 'alert(timeout)',
+      async action() {
+        await alert('shorthand alert',{
+          timeout:2000,
+        });
+        console.log('closed');
+      },
+    },
+    {
       label: 'confirm',
       async action() {
         let value = await confirm('shorthand confirm');
@@ -165,6 +174,15 @@
         setTimeout(() => {
           i.close();
         }, 2000);
+      },
+    },
+    {
+      label: 'indicator(timeout)',
+      async action() {
+        await indicator({
+          fill: 'skyblue',
+          timeout: 2000,
+        });
       },
     },
     {


### PR DESCRIPTION
## 対応内容

- モーダル呼ぶ時に第二引数に `timeout: 秒数`を指定すると自動で閉じるよう対応
- shorthand にも timeout を追加

## 確認方法

- [ ] 一番下の`timeout`のボタンを押して自動で閉じるか
- [ ] shorthand の箇所で指定した時間で modal が閉じるか

## リンク

- 確認URL ... https://deploy-preview-19--svelte-modal-manager.netlify.app/
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/ccprj1223akg02su8aag)

## スクショ

[![Image from Gyazo](https://i.gyazo.com/c76cebbec8f3fd1b01ff4657426e9d6f.gif)](https://gyazo.com/c76cebbec8f3fd1b01ff4657426e9d6f)