### PR TITLE
modal-prompt の cancel と modal 外クリックは value を空にしてキャンセルの判定を出来るようにする対応

### DIFF
--- a/src/lib/modals/Prompt.svelte
+++ b/src/lib/modals/Prompt.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
   export const dispatch = createEventDispatcher();
   export let close;
   // svelte-ignore unused-export-let
@@ -11,12 +11,21 @@
   export let message = '';
   export let value = '';
 
+  let _value = value;
+
+  onMount(() => {
+    // 渡ってきたvalueを空にする
+    value = '';
+  });
+
   let submit = () => {
+    value = _value;
     dispatch('submit', {
       value,
     });
     close();
   };
+
 </script>
 
 <template lang='pug'>
@@ -28,7 +37,7 @@
           p.text-center.white-space-pre-wrap.word-break-word {message}
       div.f
         // svelte-ignore a11y-autofocus
-        input.s-full.p8.rounded-8.bg-white(bind:value='{value}', type='text', autofocus)
+        input.s-full.p8.rounded-8.bg-white(bind:value='{_value}', type='text', autofocus)
     div.f
       button.bg-transparent.border-none.f.fh.s-full.p16.cursor-pointer(type='button', on:click!='{close}') Cancel
       button.bg-transparent.border-none.f.fh.s-full.p16.cursor-pointer.border-left OK

--- a/src/lib/modals/Prompt.svelte
+++ b/src/lib/modals/Prompt.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { createEventDispatcher } from 'svelte';
   export const dispatch = createEventDispatcher();
   export let close;
   // svelte-ignore unused-export-let
@@ -12,11 +12,8 @@
   export let value = '';
 
   let _value = value;
-
-  onMount(() => {
-    // 渡ってきたvalueを空にする
-    value = '';
-  });
+  // 渡ってきたvalueを空にする
+  value = '';
 
   let submit = () => {
     value = _value;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -80,7 +80,9 @@
         });
 
         let result = await modal.awaitClose();
-        console.log('awaitClose test', result);
+        if (result) {
+          console.log('awaitClose test', result);
+        }
       },
     },
     {


### PR DESCRIPTION
## 対応内容

- modal-prompt で cancel と modal 外クリックは value を空にする

## 確認方法

- [ ] modal-prompt を開いていただき value がある時だけ console が出るかご確認お願い致します

## リンク

- 確認URL ... https://deploy-preview-20--svelte-modal-manager.netlify.app/
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cg9878i23akg02sjk7b0)

## スクショ

![image](https://user-images.githubusercontent.com/82699620/225811640-99e7ab21-8395-4370-8b91-007f42fbd9d3.png)

![image](https://user-images.githubusercontent.com/82699620/225811618-0d11e598-c502-467c-a1af-23012eb3ea91.png)
