### PR TITLE
全体的に設計を改修

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 !.env.example
 .vercel
 .output
+
+_svelte-modal-manager-types

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ svelte-modal-manager is ...
 ## Install
 
 ```bash
-npm install svelte-modal-manager --save
+npm install @rabee-org/svelte-modal-manager --save
 ```
 
 ## Usage
@@ -20,12 +20,17 @@ npm install svelte-modal-manager --save
 ```html
 <script>
   import { onMount } from 'svelte';
-  import { openModal, alert } from 'svelte-modal-manager';
+  import { modalAlert } from '@rabee-org/svelte-modal-manager';
+  import { modalConfirm } from '$modal';
 
-  onMount(() => {
-    let modal = openModal('alert', {
+  onMount(async () => {
+    let modal = modalAlert.open({
       title: 'Hello, svelte-modal-manager',
     });
+    
+    await modal.awaitClose();
+
+    const ok = await modalConfirm.openSync('OK?');
   });
 </script>
 ```

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { create } from './index.js';
+
+const [, , cmd, ...args] = process.argv;
+const commandArgs = [];
+const options = {};
+args.reduce((o, v) => {
+  if (v.startsWith('-')) {
+    o.optionName = '';
+    let name = v.replace(/^-+/g, '');
+    if (name.includes('=')) {
+      const splitted = name.split('=');
+      name = splitted.shift();
+      options[name] = splitted.join('=');
+    }
+    else {
+      options[name] = '';
+      o.optionName = name;
+    }
+    return o;
+  }
+  else {
+    if (o.optionName) {
+      options[o.optionName] = v;
+      o.optionName = '';
+    } else {
+      commandArgs.push(v);
+    }
+    return o;
+  }
+}, { optionName: '' });
+
+const commands = {
+  create,
+};
+(async () => {
+  try {
+    if (!commands[cmd]) throw new Error(`command: ${cmd} not found.\ncommands: ${Object.keys(commands).join(', ')}`);
+    
+    commands[cmd](commandArgs, options);
+  }
+  catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})();

--- a/bin/constants.js
+++ b/bin/constants.js
@@ -22,7 +22,7 @@ const TEMPLATE_SCRIPT = `<svelte:options accessors={true}/>
 </script>
 
 <script>
-  import { getModalContext } from '@rabee-org/svelte-modal-manager';
+  import { getModalContext } from '../index.js';
   
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 

--- a/bin/constants.js
+++ b/bin/constants.js
@@ -1,0 +1,65 @@
+const TEMPLATE_SCRIPT = `<svelte:options accessors={true}/>
+<script context="module">
+  /** @type {import('@rabee-org/svelte-modal-manager/types').ModalDefaultOptions} */
+  export const { dismissible, position, focus, transition, overlay, timeout } = {
+    // dismissible: false,
+    // position: { x: 'center', y: 'middle' },
+    // focus: false,
+    // transition: {
+    //   type: fly,
+    //   props: {
+    //     y: 8,
+    //     duration: 256,
+    //   },
+    // },
+    // overlay: {
+    //   styles: {
+    //     background: 'rgba(0, 0, 0, 0.75)',
+    //   },
+    // },
+    // timeout: 2000,
+  };
+</script>
+
+<script>
+  import { getModalContext } from '@rabee-org/svelte-modal-manager';
+  
+  const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
+
+  
+</script>
+`;
+
+export const getStyleTemplate = (lang = '') => `<style${(lang === 'css' || !lang) ? '' : ` lang="${lang}"`}>
+  .modal {
+    min-width: 300px;
+    max-width: 90vw;
+    width: 340px;
+    background-color: rgba(255, 255, 255, 0.90);
+    border-radius: 8px;
+  }
+</style>
+`;
+
+
+const TEMPLATE_MARKUP_PUG = `<template lang="pug">
+  div.modal
+</template>
+`;
+
+const TEMPLATE_MARKUP_HTML = `<div class="modal">
+</div>
+`;
+
+const TEMPLATE_MARKUP = {
+  pug: TEMPLATE_MARKUP_PUG,
+  html: TEMPLATE_MARKUP_HTML,
+};
+
+export const getTemplate = ({ template = 'html', style = '' } = {}) => {
+  return [
+    TEMPLATE_SCRIPT,
+    TEMPLATE_MARKUP[template],
+    getStyleTemplate(style),
+  ].join('\n');
+};

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,36 @@
+import path from 'path';
+import fs from 'fs';
+import { getTemplate } from "./constants.js";
+
+export const create = (args, options = {}) => {
+  const example = `example: svelte-modal-manager create Menu -t pug -d ./src/components/modals" -s less`;
+  const name = args[0];
+  if (!name) {
+    throw new Error('first argument is required.\n' + example);
+  }
+
+  let template = (options.template || options.t || 'html').toLowerCase();
+  if (!/html|pug/.test(template)) {
+    throw new Error(`invalid template: ${template}. template must be html or pug.\n${example}`);
+  }
+
+  let dir = options.dir || options.d || './src/components/modals';
+  dir = path.resolve(dir);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  let style = (options.style || options.s || 'css').toLowerCase();
+
+  const filePath = path.resolve(dir, name + '.svelte');
+  if (fs.existsSync(filePath)) { 
+    throw new Error(`file already exists: ${filePath}`);
+  }
+
+  fs.writeFileSync(filePath, getTemplate({
+    style,
+    template,
+  }));
+
+  console.log(`created: ${filePath}`);
+};

--- a/package.json
+++ b/package.json
@@ -53,13 +53,32 @@
   "type": "module",
   "dependencies": {
   },
-  "files": ["package"],
+  "bin": "./bin/bin.js",
+  "files": [
+    "package",
+    "bin"
+  ],
   "main": "./package/index.js",
   "exports": {
     ".": {
       "types": "./package/index.d.ts",
       "svelte": "./package/index.js",
       "default": "./package/index.js"
+    },
+    "./vite": {
+      "types": "./package/vite/index.d.ts",
+      "svelte": "./package/vite/index.js",
+      "default": "./package/vite/index.js"
+    }
+  },
+  "typesVersions": {
+    ">4.0": {
+      "vite": [
+        "./package/vite/index.d.ts"
+      ],
+      "types": [
+        "./package/types/index.d.ts"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "release": "npm run package && npm publish",
     "icon": "fontcustom compile ./static/images/icons --font_name icons --output static/icons/",
     "check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch"
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
+    "modal:create": "node bin/bin.js create -t=pug -d ./src/components/modals -s less"
   },
   "config": {
     "gae": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rabee-org/svelte-modal-manager",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "svelte-modal-manager is ...",
   "keywords": [
     "svelte",

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -56,8 +56,6 @@
   /** @type {HTMLDivElement | null} */
   export let root = null;
 
-  let timeoutId;
-
   const onOpened = () => {
     dispatch('opened');
   };

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -2,7 +2,7 @@
 
 <script>
   import { onDestroy, createEventDispatcher, setContext } from 'svelte';
-  import { CONTEXT_KEY } from '@rabee-org/svelte-modal-manager';
+  import { CONTEXT_KEY } from './index.js';
   import { writable } from 'svelte/store';
   import { fade, fly } from 'svelte/transition';
   export const result = writable();

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -2,7 +2,7 @@
 
 <script>
   import { onDestroy, createEventDispatcher, setContext } from 'svelte';
-  import { CONTEXT_KEY } from 'svelte-modal-manager';
+  import { CONTEXT_KEY } from '@rabee-org/svelte-modal-manager';
   import { writable } from 'svelte/store';
   import { fade, fly } from 'svelte/transition';
   export const result = writable();

--- a/src/lib/ModalContainer.svelte
+++ b/src/lib/ModalContainer.svelte
@@ -10,7 +10,7 @@
   export let transition = {
     type: fly,
     props: {
-      y:64, duration: 256
+      y: 64, duration: 256
     }
   };
   export let overlay = {
@@ -24,7 +24,7 @@
   export let modal;
   export let props;
   export let visible = false; // 初期は非表示
-  export let destory;
+  export let destroy;
 
   let root;
   let timeoutId;
@@ -44,7 +44,7 @@
   });
 
   let create = () => {
-    // trigger open evnet
+    // trigger open event
     dispatch('open');
 
     if (modal.dispatch) {
@@ -54,7 +54,7 @@
 
   export let close = () => {
     visible = false;
-    // trigger close evnet
+    // trigger close event
     dispatch('close');
 
     if (timeoutId) {
@@ -78,7 +78,7 @@
     return _closePromise;
   };
 
-  let getPostionClass = () => {
+  let getPositionClass = () => {
     let x = {
       'left': 'fl',
       'center': 'fc',
@@ -96,12 +96,12 @@
 </script>
 
 <template lang='pug'>
-  div.f.s-full.scroll-stopper(bind:this='{root}', class='{getPostionClass()}', on:click!='{props.dismissible !== false && close}')
+  div.f.s-full.scroll-stopper(bind:this='{root}', class='{getPositionClass()}', on:click!='{props.dismissible !== false && close}')
     +if('visible')
       //- overlay
       div.absolute.trbl0.overlay(style='background-color: {overlay.styles.background}', transition:fade='{{duration: 128}}')
       //- modal
-      div.relative(bind:this='{modalElement}', transition:transition_type='{transition.props}', on:click|stopPropagation, on:introstart!='{create}', on:outroend!='{destory}').
+      div.relative(bind:this='{modalElement}', transition:transition_type='{transition.props}', on:click|stopPropagation, on:introstart!='{create}', on:outroend!='{destroy}').
         <!-- memo: pug だと変数展開部分で npm run package した歳にエラーがでる -->
         <svelte:component bind:this='{modal}' this='{component}' close='{close}' awaitClose='{awaitClose}' {...props} />
 </template>

--- a/src/lib/ModalManager.svelte
+++ b/src/lib/ModalManager.svelte
@@ -1,58 +1,169 @@
 <svelte:options accessors={true}/>
+<script context="module">
+  ; // ソースマップが出力されないバグがあるため ; を消さないでください
+
+  /** @type {ProxyHandler<import('./types').ModalManagementItem<ModalContainer, any>>} */
+  const MODAL_PROXY_HANDLER = {
+    get: (target, prop) => {
+      if (prop === 'isClosed' || prop === 'result') {
+        return get(target.context[prop]);
+      }
+      if (prop === 'close' || prop === 'awaitClose') {
+        return target.context[prop];
+      }
+      if (prop === '$on') {
+        // @ts-ignore
+        return (...args) => {
+          // @ts-ignore
+          const off = target.container?.$on(...args);
+          return off || (() => {});
+        }
+      }
+      if (!target.container?.modal) return ;
+      // @ts-ignore
+      return target.container.modal?.[prop];
+    },
+    set: (target, prop, value) => {
+      if (!target.container?.modal) return true;
+      // @ts-ignore
+      target.container.modal[prop] = value;
+      return true;
+    },
+  };  
+</script>
 
 <script>
   import {onMount, onDestroy} from 'svelte';
   import ModalContainer from "./ModalContainer.svelte";
+  import { get } from 'svelte/store';
 
+  /** @type {HTMLElement} */
   let root;
-  let _containers = [];
 
-  export const open = (component, props = {}) => {
-    root.classList.remove('hide');
+  /**
+   * @typedef {{ manager: import('./types').ModalManagementItem<ModalContainer, any>, proxy: import('./types').ModalProxy<any, any> }} ProxyMapItem
+   */
 
-    var container = new ModalContainer({
+  /** @type {Map<Element | null | undefined, ProxyMapItem>} */
+  let proxyMap = new Map();
+
+
+  onDestroy(() => {
+    closeAll(true);
+  });
+
+  /**
+   * modal を開く
+   * @template U
+   * @template {import('./types').CreateModalControllerArgument} T
+   * @param {T} module
+   * @param {import('./types').ModalOpenProps<InstanceType<T["default"]>>} props
+   */
+  export const open = (module, props = {}) => {
+    
+    // /** @type {(keyof import('./types').ModalOpenOptions)[]} ModalOpenOptions のすべてのキーを含む必要があります */
+    const ignore_keys = /** @type {const} */ (['transition', 'position', 'focus', 'timeout', 'dismissible', 'overlay']);
+
+    /** @type {import('./types').Equals<ignore_keys[number], keyof import('./types').ModalOpenOptions>} */
+    const __check = true;
+
+    /** @type {import('./types').ModalProps<InstanceType<T["default"]>>} */
+    const modal_props = {};
+    Object.assign(modal_props, props);
+    ignore_keys.forEach(key => {
+      delete modal_props[key];
+    });
+    Object.assign(modal_props, props.props || {});
+
+    const container = new ModalContainer({
       target: root,
       props: {
-        component: component.default,
-        position: component.position,
-        transition: component.transition,
-        overlay: component.overlay,
+        component: module.default,
+        transition: props.transition || module.transition,
+        // @ts-ignore
+        position: props.position ?? module.position,
+        dismissible: props.dismissible ?? module.dismissible,
+        overlay: module.overlay,
         props: {
-          ...component.defaultProps,
-          ...props,
+          ...modal_props,
         },
         destroy: () => {
+          // リストから削除
+          proxyMap.delete(container.root);
           // インタンスを削除
           container.$destroy();
-          // リストから削除
-          let index = _containers.findIndex(item => item === container);
-          _containers.splice(index, 1);
-
-          // すべてのモーダルがなくなったらモーダル自体を非表示に
-          if (root.children.length <= 0) {
-            root.classList.add('hide');
-          }
         },
       }
     });
 
-    // リストに追加
-    _containers.push(container);
+    const manager = {
+      container,
+      dismissible: props.dismissible ?? module.dismissible,
+      context: container.MODAL_CONTEXT,
+    };
+
+    const proxy = generateModalProxy(manager);
+
+    proxyMap.set(container.root, { manager, proxy });
 
     // modal を実際に表示
     container.visible = true;
 
-    // modal instance を返す
-    return container.modal;
+    // modal 内に focus がない場合は modal の枠にフォーカスする。
+    if (props.focus !== false && !container?.modalElement?.contains(document.activeElement)) {
+      container?.modalElement?.focus();
+    }
+
+    // modal呼ぶ側でtimeoutに秒数を指定した場合にsetTimeoutを実行する
+    if (props.timeout) {
+      setTimeout(() => {
+        proxy.close();
+      }, props.timeout);
+    }
+
+    // proxy を返す
+    return proxy;
   };
 
-  let onKeydown = (e) => {
-    let current_instance = _containers[_containers.length-1];
-    if (!current_instance) return ;
+  /**
+   * 
+   * @param {import('./types').ModalManagementItem<ModalContainer, any>} manager
+   * @returns {import('./types').ModalProxy<any, any>}
+   */
+  const generateModalProxy = (manager) => {
+    // @ts-ignore
+    return new Proxy(manager, MODAL_PROXY_HANDLER);
+  };
 
+  const getCurrentProxy = () => {
+    // 最後の要素を返す
+    let current;
+    for (const value of proxyMap.values()) {
+      current = value;
+    }
+    return current;
+  };
+
+  export const getCurrent = () => {
+    const proxy = getCurrentProxy();
+    return proxy?.proxy;
+  };
+
+  export const closeAll = (force = false) => {
+    for (const { proxy, manager } of [...proxyMap.values()]) {
+      if (force || manager.dismissible !== false) {
+        proxy.close();
+      }
+    }
+  };
+
+  const onKeydown = (e) => {
     // esc だったら close する
-    if (current_instance.props.dismissible !== false && e.code === 'Escape') {
-      current_instance.close();
+    if (e.code === 'Escape') {
+      let current = getCurrentProxy();
+      if (!current) return ;
+      current.manager?.dismissible !== false && 
+      current.proxy?.close();
     }
   };
 </script>
@@ -60,11 +171,13 @@
 <svelte:window on:keydown='{onKeydown}' />
 
 <template lang='pug'>
-  div.modal-wrapper.hide(bind:this='{root}')
+  div.modal-manager(bind:this='{root}')
 </template>
 
 <style lang='less'>
-  .modal-wrapper {
+  .modal-manager {
+    transform: translate3d(0, 0, 0);
+    visibility: hidden;
     position: fixed;
     top: 0;
     right: 0;
@@ -80,10 +193,6 @@
         bottom: 0;
         left: 0;
       }
-    }
-
-    &.hide {
-      display: none;
     }
   }
 </style>

--- a/src/lib/ModalManager.svelte
+++ b/src/lib/ModalManager.svelte
@@ -106,8 +106,9 @@
     // modal を実際に表示
     container.visible = true;
 
+    const focus = props.focus ?? module.focus;
     // modal 内に focus がない場合は modal の枠にフォーカスする。
-    if (props.focus !== false && !container?.modalElement?.contains(document.activeElement)) {
+    if (focus !== false && !container?.modalElement?.contains(document.activeElement)) {
       container?.modalElement?.focus();
     }
 

--- a/src/lib/ModalManager.svelte
+++ b/src/lib/ModalManager.svelte
@@ -1,7 +1,5 @@
 <svelte:options accessors={true}/>
 <script context="module">
-  ; // ソースマップが出力されないバグがあるため ; を消さないでください
-
   /** @type {ProxyHandler<import('./types').ModalManagementItem<ModalContainer, any>>} */
   const MODAL_PROXY_HANDLER = {
     get: (target, prop) => {
@@ -54,7 +52,6 @@
 
   /**
    * modal を開く
-   * @template U
    * @template {import('./types').CreateModalControllerArgument} T
    * @param {T} module
    * @param {import('./types').ModalOpenProps<InstanceType<T["default"]>>} props

--- a/src/lib/ModalManager.svelte
+++ b/src/lib/ModalManager.svelte
@@ -7,8 +7,7 @@
   let root;
   let _containers = [];
 
-  // svelte-ignore unused-export-let
-  export let open = (component, props = {}) => {
+  export const open = (component, props = {}) => {
     root.classList.remove('hide');
 
     var container = new ModalContainer({
@@ -22,7 +21,7 @@
           ...component.defaultProps,
           ...props,
         },
-        destory: () => {
+        destroy: () => {
           // インタンスを削除
           container.$destroy();
           // リストから削除

--- a/src/lib/modals/Alert.svelte
+++ b/src/lib/modals/Alert.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { getModalContext } from 'svelte-modal-manager';
+  import { getModalContext } from '@rabee-org/svelte-modal-manager';
   
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
   export let title = '';

--- a/src/lib/modals/Alert.svelte
+++ b/src/lib/modals/Alert.svelte
@@ -1,21 +1,19 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { createEventDispatcher } from 'svelte';
-  export const dispatch = createEventDispatcher();
-  export let close;
-  // svelte-ignore unused-export-let
-  export let awaitClose;
-
+  import { getModalContext } from 'svelte-modal-manager';
+  
+  const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
   export let title = '';
   export let message = '';
 
-  let submit = () => {
+  const submit = () => {
     dispatch('submit');
     close();
   };
 </script>
 
+<!-- svelte-ignore a11y-autofocus -->
 <template lang='pug'>
   div.modal.rounded-8
     div.p16.border-bottom
@@ -23,7 +21,7 @@
       +if('message')
         p.text-center.white-space-pre-wrap.word-break-word.m0 {message}
     div
-      button.bg-transparent.border-none.f.fh.s-full.p16.cursor-pointer(on:click!='{submit}') OK
+      button.bg-transparent.border-none.f.fh.s-full.p16.cursor-pointer(autofocus, on:click!='{submit}') OK
 </template>
 
 <style lang='less'>

--- a/src/lib/modals/Alert.svelte
+++ b/src/lib/modals/Alert.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { getModalContext } from '@rabee-org/svelte-modal-manager';
+  import { getModalContext } from '../index.js';
   
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
   export let title = '';

--- a/src/lib/modals/Auth.svelte
+++ b/src/lib/modals/Auth.svelte
@@ -1,23 +1,22 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { createEventDispatcher } from 'svelte';
-  export const dispatch = createEventDispatcher();
-  // svelte-ignore unused-export-let
-  export let close;
-  // svelte-ignore unused-export-let
-  export let awaitClose;
+  import { getModalContext } from 'svelte-modal-manager';
+
+  const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 
   export let mode = 'signup';
   export let email = '';
   export let password = '';
 
   let submit = () => {
-    dispatch('submit', {
+    const detail = {
       mode,
       email,
       password,
-    });
+    };
+    result.set(detail);
+    dispatch('submit', detail);
   };
 </script>
 

--- a/src/lib/modals/Auth.svelte
+++ b/src/lib/modals/Auth.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { getModalContext } from '@rabee-org/svelte-modal-manager';
+  import { getModalContext } from '../index.js';
 
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 

--- a/src/lib/modals/Auth.svelte
+++ b/src/lib/modals/Auth.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { getModalContext } from 'svelte-modal-manager';
+  import { getModalContext } from '@rabee-org/svelte-modal-manager';
 
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 

--- a/src/lib/modals/Confirm.svelte
+++ b/src/lib/modals/Confirm.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { getModalContext } from "@rabee-org/svelte-modal-manager";
+  import { getModalContext } from "../index.js";
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
   
   export let title = '';

--- a/src/lib/modals/Confirm.svelte
+++ b/src/lib/modals/Confirm.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { getModalContext } from "svelte-modal-manager";
+  import { getModalContext } from "@rabee-org/svelte-modal-manager";
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
   
   export let title = '';

--- a/src/lib/modals/Confirm.svelte
+++ b/src/lib/modals/Confirm.svelte
@@ -1,27 +1,23 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { createEventDispatcher } from 'svelte';
-  export const dispatch = createEventDispatcher();
-  export let close;
-  // svelte-ignore unused-export-let
-  export let awaitClose;
-
+  import { getModalContext } from "svelte-modal-manager";
+  const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
+  
   export let title = '';
   export let message = '';
-  export let value = '';
 
   let yes = () => {
-    value = true;
+    $result = true;
     dispatch('submit', {
-      value,
+      value: true,
     });
     close();
   };
   let no = () => {
-    value = false;
+    $result = false;
     dispatch('submit', {
-      value,
+      result: false,
     });
     close();
   };

--- a/src/lib/modals/Indicator.svelte
+++ b/src/lib/modals/Indicator.svelte
@@ -5,19 +5,11 @@
   export const transition = {
     type: fade,
   };
-
-  export const defaultProps = {
-    // デフォルトは解放できないようにする
-    dismissible: false,
-  };
+  // デフォルトは解放できないようにする
+  export const dismissible = false;
 </script>
 
 <script>
-  // svelte-ignore unused-export-let
-  export let close;
-  // svelte-ignore unused-export-let
-  export let awaitClose;
-
   export let fill = '#aaaaaa';
 </script>
 

--- a/src/lib/modals/Prompt.svelte
+++ b/src/lib/modals/Prompt.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { getModalContext } from 'svelte-modal-manager';
+  import { getModalContext } from '@rabee-org/svelte-modal-manager';
   
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 

--- a/src/lib/modals/Prompt.svelte
+++ b/src/lib/modals/Prompt.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { getModalContext } from '@rabee-org/svelte-modal-manager';
+  import { getModalContext } from '../index.js';
   
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 

--- a/src/lib/modals/Prompt.svelte
+++ b/src/lib/modals/Prompt.svelte
@@ -1,24 +1,21 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { createEventDispatcher } from 'svelte';
-  export const dispatch = createEventDispatcher();
-  export let close;
-  // svelte-ignore unused-export-let
-  export let awaitClose;
+  import { getModalContext } from 'svelte-modal-manager';
+  
+  const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 
   export let title = '';
   export let message = '';
   export let value = '';
+  result.set('');
 
   let _value = value;
-  // 渡ってきたvalueを空にする
-  value = '';
 
   let submit = () => {
-    value = _value;
+    result.set(_value);
     dispatch('submit', {
-      value,
+      value: _value,
     });
     close();
   };

--- a/src/lib/modals/SideMenu.svelte
+++ b/src/lib/modals/SideMenu.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <script>
-  import { getModalContext, modalAlert } from '@rabee-org/svelte-modal-manager';
+  import { getModalContext, modalAlert } from '../index.js';
   
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 

--- a/src/lib/modals/SideMenu.svelte
+++ b/src/lib/modals/SideMenu.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <script>
-  import { getModalContext, modalAlert } from 'svelte-modal-manager';
+  import { getModalContext, modalAlert } from '@rabee-org/svelte-modal-manager';
   
   const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 

--- a/src/lib/modals/SideMenu.svelte
+++ b/src/lib/modals/SideMenu.svelte
@@ -6,7 +6,7 @@
   export const transition = {
     type: fly,
     props: {
-      x: 375,
+      x: 200,
       duration: 256,
     },
   };
@@ -22,13 +22,9 @@
 </script>
 
 <script>
-  import { createEventDispatcher, onMount } from 'svelte';
-  export const dispatch = createEventDispatcher();
-  // svelte-ignore unused-export-let
-  export let close;
-  // svelte-ignore unused-export-let
-  export let awaitClose;
-
+  import { getModalContext, modalAlert } from 'svelte-modal-manager';
+  
+  const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 
   export let title = 'Side Menu';
   export let items = [];
@@ -41,7 +37,7 @@
   //   close();
   // };
   let openAlert = () => {
-    openModal('alert', {
+    modalAlert.open({
       message: 'こんな感じでモーダル重ねられるよ!',
     });
   };

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -1,0 +1,171 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { Writable } from 'svelte/store';
+import type { DispatchOptions } from "svelte/internal";
+import type { TransitionConfig } from "svelte/transition";
+
+// REF: https://www.sunapro.com/tuple-type-check/
+export type Equals<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends
+  (<T>() => T extends Y ? 1 : 2) ? true : false;
+
+export type Expect<T extends true> = T;
+
+
+type OptionalProps<T> = { [K in keyof T]?: T[K] };
+
+// Returns a type with the same well-known props, but without the index signature
+type NoIndex<T> = {
+  [K in keyof T as {} extends Record<K, 1> ? never : K]: T[K]
+}
+
+// Omit from NoIndex version of T, and then intersects with the indexed part of it
+type OmitFromKnownKeys<T, K extends keyof NoIndex<T>> = Omit<NoIndex<T>, K>;// & OnlyIndex<T>;
+
+class DefaultComponent extends SvelteComponentTyped<>{ };
+
+type IgnorePropKeys = keyof NoIndex<{
+  [K in keyof DefaultComponent]: any;
+}> | 'dispatch' | 'close' | 'awaitClose';
+
+export type ModalConstructorProps<T> = OptionalProps<OmitFromKnownKeys<T, IgnorePropKeys>>;
+
+export type ModalTransition = {
+  /**
+   * transition の種類。
+   * 
+   * e.g.   
+   * `import { fly } from 'svelte/transition';`
+   * 
+   * `type: fly,`
+   */
+  type?: any,
+
+  /**
+   * transition に渡す props。
+   * 
+   * この部分に渡されるものです。
+   * 
+   * `transition:fly={props}`
+   */
+  props?: any,
+};
+
+type ModalPosition = {
+  x?: 'left' | 'center' | 'right' | '' | undefined | null;
+  y?: 'top' | 'middle' | 'bottom' | '' | undefined | null;
+};
+
+export type ModalContainerOptions = {
+  /**
+   * Esc キーや modal 外クリックで閉じるかどうかを指定します。
+   * false を指定すると close 関数でしか閉じられなくなります。
+   * 
+   * ℹ️ modal の `export let dismissible` に代入するには、 `{ props: { dismissible } }` としてください。
+   * @default true
+   */
+  dismissible?: boolean | undefined;
+  
+  /**
+   * overlay の styles を指定できます。
+   * 
+   * ℹ️ modal の `export let overlay` に代入するには、 `{ props: { overlay } }` としてください。
+   */
+  overlay?: {
+    styles: {
+      background: string;
+    };
+  };
+};
+
+type ModalOpenOptions = {
+  /** 
+   * modal 開閉時の transition を指定できます。
+   * 
+   * ℹ️ modal の `export let transition` に代入するには、 `{ props: { transition } }` としてください。
+   **/
+  transition?: ModalTransition;
+
+  /**
+   * target を指定した場合に target からの相対位置として、どの位置に modal を開くかを指定します。
+   * 
+   * ℹ️ modal の `export let position` に代入するには、 `{ props: { position } }` としてください。
+   * 
+   * @default { x: 'center', y: 'middle' }
+   */
+  position?: ModalPosition,
+
+
+  /**
+   * modal を開いたときに modal の外枠に focus を当てるかどうかを指定します。
+   * 
+   * ℹ️ modal の `export let focus` に代入するには、 `{ props: { focus } }` としてください。
+   * @default true
+   */
+  focus?: boolean;
+
+  /**
+   * timeout で指定した時間 (ms) 経過後に modal を閉じます。
+   * 
+  * ℹ️ modal の `export let timeout` に代入するには、 `{ props: { timeout } }` としてください。
+   */
+  timeout?: number;
+
+} & ModalContainerOptions;
+
+export type ModalModule<T> = ModalOpenOptions & {
+  default: T;
+};
+
+export type CreateModalControllerArgument = Omit<ModalModule<any>, 'position'> & {
+  position?: { x: string;  y: string};
+};
+
+export type ModalProps<T> = OptionalProps<OmitFromKnownKeys<T, IgnorePropKeys>>;
+export type ModalOpenProps<T> = OptionalProps<OmitFromKnownKeys<ModalProps<T>, (keyof ModalOpenOptions) | "props">>
+  & ModalOpenOptions
+  & { props?: ModalProps<T> };
+
+/** modal open のデフォルトとして指定できるパラメーター */
+export type ModalDefaultOptions = ModalOpenOptions;
+
+export class ModalComponent<T> extends SvelteComponentTyped<ModalConstructorProps<T>> {};
+
+export type ModalComponentConstructor<T> = {
+  new(props: ModalConstructorProps<T>): ModalComponent<T>;
+};
+
+export type ModalContext<T> = {
+  /** modal を閉じ result を返します。 close イベントが発火します。 */
+  readonly close: () => T;
+  /** modal が閉じると resolve されます。 Promise<result> を返します。 */
+  readonly awaitClose: () => Promise<T>;
+  readonly isClosed: Writable<boolean>;
+  readonly result: Writable<T>;
+  readonly dispatch: <EventKey extends string>(type: EventKey, detail?: any) => void;
+};
+
+export type ModalProxy<P, R> = Pick<ModalContext<R>, "awaitClose" | "close"> & ModalConstructorProps<P> & Pick<P, '$on' | '$set'> & {
+  /** modal が閉じているかどうか。 modal が閉じると true になります。 */
+  readonly isClosed: boolean;
+  /** 
+   * modal の result。
+   * 何が入るかは modal 側の実装によります。 
+   * modal.close() や await modal.awaitClose() で取得できるものと同じです。
+   */
+  readonly result: R;
+};
+
+export type ModalController<T, R> = {
+  readonly static: T,
+  /** modal を開き modal のインスタンスを返します。 */
+  readonly open: (props: ModalOpenProps<InstanceType<T["default"]>>) => ModalProxy<InstanceType<T["default"]>, R>;
+  /** modal を開き閉じるまで待ちます。(awaitClose() を実行したのと同じです。) */
+  readonly openSync: (props: ModalOpenProps<InstanceType<T["default"]>>) => Promise<R>;
+};
+
+export type ModalControllerProxy<T, R> = T & ModalController<T, R>;
+
+export type ModalManagementItem<C, T> = {
+  container?: C,
+  context: ModalContext<T>
+} & ModalContainerOptions;

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -158,9 +158,9 @@ export type ModalProxy<P, R> = Pick<ModalContext<R>, "awaitClose" | "close"> & M
 export type ModalController<T, R> = {
   readonly static: T,
   /** modal を開き modal のインスタンスを返します。 */
-  readonly open: (props: ModalOpenProps<InstanceType<T["default"]>>) => ModalProxy<InstanceType<T["default"]>, R>;
+  readonly open: (props?: ModalOpenProps<InstanceType<T["default"]>>) => ModalProxy<InstanceType<T["default"]>, R>;
   /** modal を開き閉じるまで待ちます。(awaitClose() を実行したのと同じです。) */
-  readonly openSync: (props: ModalOpenProps<InstanceType<T["default"]>>) => Promise<R>;
+  readonly openSync: (props?: ModalOpenProps<InstanceType<T["default"]>>) => Promise<R>;
 };
 
 export type ModalControllerProxy<T, R> = T & ModalController<T, R>;

--- a/src/lib/vite/index.js
+++ b/src/lib/vite/index.js
@@ -1,0 +1,225 @@
+import path from 'path';
+import fs from 'fs';
+
+const PACKAGE_NAME = '@rabee-org/svelte-modal-manager';
+const TYPE_DIR_NAME = '_svelte-modal-manager-types';
+
+const rmdirSync = (path = '') => {
+  fs.rmSync(path, { recursive: true, force: true });
+};
+
+const mkdirSync = (path = '') => {
+  if (!fs.existsSync(path)) {
+    fs.mkdirSync(path, { recursive: true });
+  }
+};
+
+/**
+ * 再帰的にファイル読み込み
+ * @param {string} dir 
+ * @param {{ extensions?: string[] }} param2
+ * @returns 
+ */
+const readDirRecursive = (dir, { extensions = [] } = {}) => {
+  /**
+   * 
+   * @param {string} dir 
+   * @param {string[]} files 
+   * @returns 
+   */
+  const _readDirRecursive = (dir, files = []) => {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    const dirs = [];
+    for (const entry of entries) {
+      if (entry.isDirectory()) dirs.push(`${dir}/${entry.name}`);
+      if (entry.isFile()) {
+        const ext = entry.name.replace(/^.*\.(.+)$/, '$1');
+        if (extensions.length === 0 || extensions.includes(ext)) {
+          files.push(`${dir}/${entry.name}`);
+        }
+      }
+    }
+    for (const d of dirs) {
+      files = _readDirRecursive(d, files);
+    }
+    return files;
+  };
+
+  return _readDirRecursive(dir, []);
+};
+
+/**
+ * 
+ * @param {(...args: any) => any} func 
+ * @param {number} ms 
+ * @returns {((...args: any) => any) & { cancel: () => void }}
+ */
+const debounce = (func, ms) => {
+  /** @type {NodeJS.Timeout} */
+  let id;
+  return Object.assign((/** @type {any[]} */ ...args) => {
+    clearTimeout(id);
+    id = setTimeout(() => func(...args), ms);
+  }, {
+    cancel: () => clearTimeout(id),
+  });
+};
+
+const toCamelCase = (str = '') => {
+  return str.replace(/-([a-zA-Z])/g, (g) => g[1].toUpperCase()).replace(/-(\d)/g, '$1');
+};
+
+const getTypeDeclare = ({ moduleName = '', componentPath = '', componentName = '' } = {}) => `declare module '${moduleName}' {
+  import type { ModalControllerProxy } from "${PACKAGE_NAME}/types";
+  import type * as ${toCamelCase(componentName)} from "${componentPath}";
+  export const ${toCamelCase('modal-' + componentName)}: ModalControllerProxy<typeof ${toCamelCase(componentName)}, any>;
+}
+`;
+
+/**
+ * modal の関数定義などの自動生成をする vite plugin を返します。
+ * @returns {import('vite').PluginOption}
+ */
+export function modalManagerPlugin({ moduleName = '$modal', componentAlias = '$modals' } = {}) {
+  /** @type {Set<string>} */
+  let fileSet = new Set();
+  const resolvedVirtualModuleName = '\0' + moduleName;
+  let componentDir = '';
+  let typesDir = '';
+  
+  const isModalComponent = (id = '') => {
+    return path.resolve(id).startsWith(componentDir) && id.endsWith('.svelte');
+  };
+  
+  const getComponentName = (id = '') => {
+    const resolvedPath = path.resolve(id);
+    const replacedPath = resolvedPath.replace(componentDir, '').replace(/^\//, '').replace(/\/|\s/g, '-');
+    return path.basename(replacedPath, '.svelte');
+  };
+
+  const getComponentPath = (id = '') => {
+    return path.resolve(id).replace(componentDir, componentAlias);
+  };
+
+  const getTypePath = (id = '') => {
+    const resolvedPath = path.resolve(id);
+    const replacedPath = resolvedPath.replace(componentDir, '').replace(/\.svelte$/, '').replace(/^\//g, '');
+    return path.resolve(typesDir, replacedPath + '.d.ts');
+  };
+
+  // 型定義ファイルの書き込み
+  const writeTypeDefinition = (id = '') => {
+    const resolvedPath = path.resolve(id);
+    const typePath = getTypePath(id);
+    mkdirSync(path.dirname(typePath));
+    fileSet.add(resolvedPath);
+    fs.writeFileSync(typePath, getTypeDeclare({
+      moduleName,
+      componentPath: getComponentPath(id),
+      componentName: getComponentName(id),
+    }));
+  };
+
+  let virtualModule = '';
+  const buildVirtualModule = () => {
+    let lines = [`import { createModalController } from '${PACKAGE_NAME}';`];
+    let count = 0;
+    fileSet.forEach((id) => {
+      const resolvedPath = path.resolve(id);
+      if (!fs.existsSync(resolvedPath)) return;
+
+      const componentPath = getComponentPath(id);
+      const componentName = toCamelCase(getComponentName(id));
+      lines.push(
+        `import * as ${componentName}_${count} from '${componentPath}';`,
+        `export const ${toCamelCase('modal-' + componentName)} = createModalController(${componentName}_${count});`
+      );
+      count++;
+    });
+    virtualModule = lines.join('\n');
+  };
+
+  const getVirtualModule = () => {
+    if (!virtualModule) {
+      buildVirtualModule();
+    }
+    return virtualModule;
+  };
+
+
+  // 削除されたコンポーネントがあるかチェックして、あれば型定義ファイルを削除し、virtual module を再構築する
+  const cleanUp = () => {
+    let isUpdated = false;
+    fileSet.forEach((id) => {
+      if (!fs.existsSync(id)) {
+        fileSet.delete(id);
+        const typePath = getTypePath(id);
+        if (fs.existsSync(typePath)) {
+          fs.rmSync(typePath);
+        }
+        isUpdated = true;
+      }
+    });
+
+    const files = readDirRecursive(componentDir, { extensions: ['svelte'] });
+    files.forEach((file) => {
+      if (!fileSet.has(file)) {
+        isUpdated = true;
+        writeTypeDefinition(file);
+      }
+    });
+    fileSet = new Set(files);
+    if (isUpdated) {
+      buildVirtualModule();
+    }
+  };
+
+  const debouncedCleanUp = debounce(cleanUp, 100);
+
+  return {
+    name: '@rabee-org/svelte-modal-manager-plugin',
+    configResolved(config) {
+      const alias = (config.resolve?.alias || []).find(alias => alias.find === componentAlias);
+      if (!alias) { 
+        throw new Error(`alias ${componentAlias} is not found.\nsvelte.config.js must have alias like this:\nalias: {\n  '${componentAlias}': path.resolve('./src/components/modals'),\n}`);
+      }
+      componentDir = path.resolve(alias.replacement);
+      typesDir = path.resolve(componentDir, TYPE_DIR_NAME);
+    },
+    buildStart() {
+      rmdirSync(typesDir);
+      mkdirSync(typesDir);
+
+      const files = readDirRecursive(componentDir, { extensions: ['svelte'] });
+      fileSet = new Set(files);
+      files.forEach(writeTypeDefinition);
+    },
+    resolveId(id) {
+      if (id === moduleName) {
+        return resolvedVirtualModuleName;
+      }
+    },
+    load(id) {
+      if (id === resolvedVirtualModuleName) {
+        return getVirtualModule();
+      }
+    },
+    handleHotUpdate(ctx) {
+      const id = path.resolve(ctx.file);
+      if (isModalComponent(id)) {
+        // 新しいファイルが追加されたら、virtual module を再生成する
+        if (!fileSet.has(id)) {
+          fileSet.add(id);
+          buildVirtualModule();
+        }
+        writeTypeDefinition(ctx.file);
+      }
+      debouncedCleanUp();
+    },
+
+    buildEnd() { 
+      debouncedCleanUp.cancel();
+      cleanUp();
+    }
+  }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,18 @@
   import Post from '$components/items/Post.svelte';
   import { modalAlert, modalAuth, modalConfirm, modalIndicator, modalPrompt, modalSideMenu } from '@rabee-org/svelte-modal-manager';
 
+  const indicator = modalIndicator.open;
+
+  /**
+   * 
+   * @param {string} message 
+   * @param {Parameters<typeof modalAlert.openSync>[0]} [props] 
+   * @returns 
+   */
+  function alert(message, props) {
+    return modalAlert.openSync({ message, ...props });
+  }
+
   // $: ({ posts } = $page.data);
   let buttons = [
     {
@@ -129,7 +141,7 @@
     {
       label: 'indicator',
       async action() {
-        let i = modalIndicator.open({
+        let i = indicator({
           fill: 'skyblue',
         });
 
@@ -161,10 +173,10 @@
     {
       label: 'esc',
       async action() {
-        modalAlert.open({message: '最後は ESC じゃ閉じられないよ', dismissible:false});
-        modalAlert.open({message:'ESC で閉じてね: 1'});
-        modalAlert.open({message:'ESC で閉じてね: 2'});
-        modalAlert.open({message:'ESC で閉じてね: 3'});
+        alert('最後は ESC じゃ閉じられないよ', {dismissible:false});
+        alert('ESC で閉じてね: 1');
+        alert('ESC で閉じてね: 2');
+        alert('ESC で閉じてね: 3');
       },
     },
     {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
   import Post from '$components/items/Post.svelte';
-    import { modalAlert, modalAuth, modalConfirm, modalIndicator, modalPrompt, modalSideMenu } from 'svelte-modal-manager';
+  import { modalAlert, modalAuth, modalConfirm, modalIndicator, modalPrompt, modalSideMenu } from '@rabee-org/svelte-modal-manager';
 
   // $: ({ posts } = $page.data);
   let buttons = [

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,15 +1,15 @@
 <script>
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
-  import { openModal, alert, confirm, prompt, indicator } from 'svelte-modal-manager';
   import Post from '$components/items/Post.svelte';
+    import { modalAlert, modalAuth, modalConfirm, modalIndicator, modalPrompt, modalSideMenu } from 'svelte-modal-manager';
 
   // $: ({ posts } = $page.data);
   let buttons = [
     {
       label: 'Alert',
       action: async () => {
-        let modal = openModal('alert', {
+        let modal = modalAlert.open({
           title: 'svelte-modal demo',
           message: 'Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text ',
         });
@@ -28,7 +28,7 @@
     {
       label: 'Confirm',
       action: () => {
-        let modal = openModal('confirm', {
+        let modal = modalConfirm.open({
           title: `Do you like programming?`,
           message: 'あなたはプログラミングが好きですか？',
         });
@@ -40,7 +40,7 @@
           console.log('modal: submit');
           
           let {value} = e.detail;
-          openModal('alert', {
+          modalAlert.open({
             title: 'message',
             message: value ? `I'm happy. I love too.` : `It's a little disappointing.`,
           });
@@ -50,7 +50,7 @@
     {
       label: 'Prompt',
       action: async () => {
-        let modal = openModal('prompt', {
+        let modal = modalPrompt.open({
           title: `What's your favorite food?`,
           message: 'あなたの好きな食べ物は何ですか？',
           value: 'banana',
@@ -63,7 +63,7 @@
           console.log('modal: submit');
           
           let {value} = e.detail;
-          openModal('alert', {
+          modalAlert.open({
             title: 'message',
             message: `Oh, I also like "${value}".`,
           });
@@ -78,7 +78,7 @@
     {
       label: 'SideMenu',
       action: () => {
-        let modal = openModal('sidemenu', {
+        let modal = modalSideMenu.open({
           title: 'svelte-modal demo',
           items: [
             { label: 'post 1', link: '/posts/1' },
@@ -100,7 +100,7 @@
     {
       label: 'auth(signup)',
       async action() {
-        let modal = openModal('auth', {
+        let modal = modalAuth.open({
           email: 'development@rabee.jp',
         });
 
@@ -114,7 +114,7 @@
     {
       label: 'auth(signin)',
       async action() {
-        let modal = openModal('auth', {
+        let modal = modalAuth.open({
           mode: 'signin',
           email: 'development@rabee.jp',
         });
@@ -127,39 +127,9 @@
       },
     },
     {
-      label: 'alert',
-      async action() {
-        await alert('shorthand alert');
-        console.log('closed');
-      },
-    },
-    {
-      label: 'alert(timeout)',
-      async action() {
-        await alert('shorthand alert',{
-          timeout:2000,
-        });
-        console.log('closed');
-      },
-    },
-    {
-      label: 'confirm',
-      async action() {
-        let value = await confirm('shorthand confirm');
-        console.log(`closed: ${value}`);
-      },
-    },
-    {
-      label: 'prompt',
-      async action() {
-        let value = await prompt('shorthand prompt');
-        console.log(`closed: ${value}`);
-      },
-    },
-    {
       label: 'indicator',
       async action() {
-        let i = indicator({
+        let i = modalIndicator.open({
           fill: 'skyblue',
         });
 
@@ -171,7 +141,7 @@
     {
       label: 'indicator(timeout)',
       async action() {
-        await indicator({
+        await modalIndicator.openSync({
           fill: 'skyblue',
           timeout: 2000,
         });
@@ -180,7 +150,8 @@
     {
       label: 'dismissible',
       async action() {
-        let value = await prompt('絶対に答えてね', {
+        let value = await modalPrompt.openSync({
+          message: '絶対に答えてね',
           title: 'dismissible',
           dismissible: false,
         });
@@ -190,16 +161,16 @@
     {
       label: 'esc',
       async action() {
-        alert('最後は ESC じゃ閉じられないよ', {dismissible:false});
-        alert('ESC で閉じてね: 1');
-        alert('ESC で閉じてね: 2');
-        alert('ESC で閉じてね: 3');
+        modalAlert.open({message: '最後は ESC じゃ閉じられないよ', dismissible:false});
+        modalAlert.open({message:'ESC で閉じてね: 1'});
+        modalAlert.open({message:'ESC で閉じてね: 2'});
+        modalAlert.open({message:'ESC で閉じてね: 3'});
       },
     },
     {
       label: 'timeout',
       async action() {
-        let modal = openModal('alert', {
+        let modal = modalAlert.open({
           title: '2秒後に閉じます',
           message: 'Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text Text ',
           timeout: 2000,

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,8 @@ const config = {
     adapter: adapter(),
     
     alias: {
-      'svelte-modal-manager': path.resolve('./src/lib'),
+      '@rabee-org/svelte-modal-manager': path.resolve('./src/lib'),
+      '$modals': path.resolve('./src/components/modals'),
       $components: path.resolve('./src/components'),
     },
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,13 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from "vite";
+import { modalManagerPlugin } from './src/lib/vite/index.js';
 
 console.log('-----------------');
 console.log('vite.config.js', process.env.NODE_ENV);
 console.log('-----------------');
 
 export default defineConfig({
-  plugins: [sveltekit()],
+  plugins: [sveltekit(), modalManagerPlugin()],
 
   define: {
     'process.env': process.env,


### PR DESCRIPTION
## 対応内容

- registerModalComponent による文字列での modal 定義を廃止
  - 理由: 文字列でのmodal定義は混乱が生じやすい
  - ライブラリ側が提供しなくても、文字列の管理は、ライブラリ外でも実装可能なため
- shorthand関数の廃止(alert, confirm など)
  - 理由: ライブラリ側が提供しなくても、ライブラリ外でも実装可能なため
  - プロジェクト側でAlertなどを上書きした場合、ライブラリ標準のAlertなのか、上書きしたAlertなのかコードを読まなければわからない
- dismissibleなどのopenModalのオプションをmodalのexport let に代入しないように修正
  - 代わりに `props: { dismissible: true }` などで代入されるように変更
  - 理由: 意図しない代入を防ぐため
- ModalController を生成する機能を実装
  - open, openSync を持つオブジェクトを生成します
- modal のテンプレートを作成するコマンドを実装 (npm run modal:create ModalName)
- モーダルファイルを作成すると自動でコンポーネントを作成するプラグインを実装 (modalManagerPlugin)

## 確認方法

- [ ] コードを確認
- [ ] 動作するか確認

## リンク

- 確認URL ... https://deploy-preview-22--svelte-modal-manager.netlify.app/
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/chvgaai23akg035a81i0)
